### PR TITLE
Weekly Updates

### DIFF
--- a/Classes/DJProfiles/DJProfile.py
+++ b/Classes/DJProfiles/DJProfile.py
@@ -416,7 +416,7 @@ class DJProfile(ManagedObject):
         main_profile = U.make_embed(
             title=self.name,
             description=dm_text,
-            color=self.color,
+            color=self.color if self.color else FroggeColor.embed_background(),
             fields=[
 
                 EmbedField(
@@ -458,12 +458,12 @@ class DJProfile(ManagedObject):
         availability = U.make_embed(
             title=f"{self.name}'s Availability",
             description=DJAvailability.long_availability_status(self.availability),
-            color=self.color,
+            color=self.color if self.color else FroggeColor.embed_background(),
             footer_text=self.links.twitch_link,
         )
 
         aboutme = U.make_embed(
-            color=self.color,
+            color=self.color if self.color else FroggeColor.embed_background(),
             title=f"About {self.name}",
             description=self.aboutme,
             footer_text=self.links.twitch_link,

--- a/Classes/DJProfiles/DJProfile.py
+++ b/Classes/DJProfiles/DJProfile.py
@@ -350,15 +350,15 @@ class DJProfile(ManagedObject):
                     value=genres1,
                     inline=True
                 ),
-                EmbedField("** **", genres2 if genres2 != "`No Items`" else "", inline=True),
-                EmbedField("** **", genres3 if genres3 != "`No Items`" else "", inline=True),
+                EmbedField("** **", genres2 if genres2 != "`-`" else "", inline=True),
+                EmbedField("** **", genres3 if genres3 != "`-`" else "", inline=True),
                 EmbedField(U.draw_line(extra=15), "", inline=False),
                 EmbedField(
                     name=f"{BotEmojis.GenericLinkIcon} __Links__ {BotEmojis.GenericLinkIcon}",
                     value=links1,
                     inline=True
                 ),
-                EmbedField("** **", links2 if links2 != "`No Items`" else "", True),
+                EmbedField("** **", links2 if links2 != "`-`" else "", True),
                 EmbedField(U.draw_line(extra=15), "", inline=False),
                 EmbedField(
                     name=f"{BotEmojis.CalendarLogo} __Availability__ {BotEmojis.CalendarLogo}",

--- a/Classes/Profiles/Profile.py
+++ b/Classes/Profiles/Profile.py
@@ -271,7 +271,7 @@ class Profile(ManagedObject):
             description += (
                 f"\n{U.draw_line(text=jobs)}\n"
                 f"{jobs}\n"
-                f"{U.draw_line(text=jobs)}\n"
+                f"{U.draw_line(text=jobs)}"
             )
         description += region_str
 

--- a/Classes/Profiles/ProfileMainInfo.py
+++ b/Classes/Profiles/ProfileMainInfo.py
@@ -253,7 +253,11 @@ class ProfileMainInfo(ProfileSection):
                 ),
                 EmbedField(
                     name="__Preferred Venue Tags__",
-                    value=U.split_lines([f"`{t.proper_name}`" for t in self._tags], 30),
+                    value=(
+                        U.split_lines([f"`{t.proper_name}`" for t in self._tags], 30)
+                        if self._tags
+                        else "`Not Set`"
+                    ),
                     inline=True
                 ),
                 EmbedField(
@@ -291,12 +295,12 @@ class ProfileMainInfo(ProfileSection):
         Tuple[str, str, Embed, bool]
         """
 
-        region_str = f"{BotEmojis.World} __**Home Region(s)**__ {BotEmojis.World} \n"
+        region_str = f"\n{BotEmojis.World} __**Home Region(s)**__ {BotEmojis.World} \n"
         if self.regions:
             combined = "/".join([region.proper_name for region in self.regions])
             region_str += f"{combined}\n"
         else:
-            region_str += "`Not Set`"
+            region_str += "`Not Set`\n"
 
         def get_pos_str(positions: List[Position]) -> str:
             return "\n".join(

--- a/Classes/Venues/VenueHours.py
+++ b/Classes/Venues/VenueHours.py
@@ -219,6 +219,8 @@ class VenueHours(Identifiable):
 
         if self._interval_type == XIVIntervalType.EveryXWeeks:
             # e.g. "Every 2 weeks on Tuesday: 10:00 AM - 2:00 PM"
+            if self._interval_arg == 1:
+                return f"Every week on {day_name}: {open_str} - {close_str}"
             return (
                 f"Every {self._interval_arg} week(s) on {day_name}: "
                 f"{open_str} - {close_str}"

--- a/Enums/LinkType.py
+++ b/Enums/LinkType.py
@@ -46,7 +46,7 @@ class LinkType(FroggeEnum):
 PATTERNS = [
     (
         LinkType.Carrd,
-        re.compile(r"^https?://(?:[\w-]+\.)*carrd\.co\S*$", flags=re.IGNORECASE)
+        re.compile(r"^https?://(?:[\w-]+\.)*(?:carrd|crd)\.co\S*$", flags=re.IGNORECASE)
     ),
     (
         LinkType.Discord,


### PR DESCRIPTION
Completed the following issues in this PR.

- #8 - Modified home regions so the newline is always added before the header line. Also added a "Not Set" default for venue tags.
- #9 - One of two subissues was a moot point because we use a string value for the start time, so it can be ignored. Did add handling for the `crd.co` domain alias tho.
- #10 - Modified the string handling for venue availabilities to read 'weekly' instead of 'every 1 weeks' when applicable.
#12 - Changed column list handling to display as blank if there's nothing in the second or third columns.
#13 - Changed default color handling in the compilation of DJ profiles in the event there is no color defined by the user.